### PR TITLE
Add submission email to Poetry & Prose event

### DIFF
--- a/content/events/2026-poetry-prose/index.md
+++ b/content/events/2026-poetry-prose/index.md
@@ -52,7 +52,7 @@ Watch young poets and storytellers compete in a high-energy slam for a **$50 cas
 * **Time Limits:**   
   * Poetry: up to 5 minutes   
   * Prose/Flash Fiction: up to 7 minutes   
-* **Submission Requirement:** All pieces must be printed and reviewed for language and subject matter prior to performance.   
+* **Submission Requirement:** All pieces must be printed and reviewed for language and subject matter prior to performance. Send a copy of your poem or prose to huguesnick@gmail.com.   
 * **Entry Limits:**   
   * Up to 3 poems per participant   
   * Up to 2 prose/flash fiction pieces per participant 


### PR DESCRIPTION
## Summary
- Adds instruction to send a copy of poem/prose to huguesnick@gmail.com, per Brian Winters (Nick Hugues).

## Test plan
- [ ] Verify the updated submission requirement renders correctly on the 2026 Poetry & Prose event page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)